### PR TITLE
Reflect that std.test.expectXX can fail.

### DIFF
--- a/src/asn1.zig
+++ b/src/asn1.zig
@@ -422,7 +422,7 @@ pub const der = struct {
         return try parse_int_with_length_internal(alloc, &read, length, der_reader);
     }
 
-    fn parse_int_with_length_internal(alloc: *Allocator, bytes_read: *usize, length: usize, der_reader: anytype) !BigInt  {
+    fn parse_int_with_length_internal(alloc: *Allocator, bytes_read: *usize, length: usize, der_reader: anytype) !BigInt {
         const first_byte = try der_reader.readByte();
         if (first_byte == 0x0 and length > 1) {
             // Positive number with highest bit set to 1 in the rest.

--- a/src/ciphersuites.zig
+++ b/src/ciphersuites.zig
@@ -151,7 +151,7 @@ pub const suites = struct {
                             error.EndOfStream => return error.ServerMalformedResponse,
                             else => |e| return e,
                         };
-                        var result: [2] u8 = undefined;
+                        var result: [2]u8 = undefined;
                         ChaCha20Stream.chacha20Xor(
                             &result,
                             &encrypted,

--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -947,13 +947,13 @@ test "elliptic curve functions with secp384r1 curve" {
         var res: u32 = ecc.decode_to_jacobian(ecc.SECP384R1, &P, ecc.SECP384R1.base_point);
         var out: [96]u8 = undefined;
         ecc.encode_from_jacobian(ecc.SECP384R1, &out, P);
-        std.testing.expectEqual(ecc.SECP384R1.base_point, out);
+        try std.testing.expectEqual(ecc.SECP384R1.base_point, out);
 
         // Multiply by one, check that the result is still the base point
         mem.set(u8, &out, 0);
         ecc.point_mul(ecc.SECP384R1, &P, &[1]u8{1});
         ecc.encode_from_jacobian(ecc.SECP384R1, &out, P);
-        std.testing.expectEqual(ecc.SECP384R1.base_point, out);
+        try std.testing.expectEqual(ecc.SECP384R1.base_point, out);
     }
 
     {
@@ -973,7 +973,7 @@ test "elliptic curve functions with secp384r1 curve" {
 
         const shared1 = try ecc.scalarmult(ecc.SECP384R1, kp1.public_key, &kp2.secret_key);
         const shared2 = try ecc.scalarmult(ecc.SECP384R1, kp2.public_key, &kp1.secret_key);
-        std.testing.expectEqual(shared1, shared2);
+        try std.testing.expectEqual(shared1, shared2);
     }
 
     // @TODO Add tests with known points.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1809,12 +1809,12 @@ test "HTTPS request on wikipedia main page" {
     }, "en.wikipedia.org");
     defer client.close_notify() catch {};
 
-    std.testing.expectEqualStrings("http/1.1", client.protocol);
+    try std.testing.expectEqualStrings("http/1.1", client.protocol);
     try client.writer().writeAll("GET /wiki/Main_Page HTTP/1.1\r\nHost: en.wikipedia.org\r\nAccept: */*\r\n\r\n");
 
     {
         const header = try client.reader().readUntilDelimiterAlloc(std.testing.allocator, '\n', std.math.maxInt(usize));
-        std.testing.expectEqualStrings("HTTP/1.1 200 OK", mem.trim(u8, header, &std.ascii.spaces));
+        try std.testing.expectEqualStrings("HTTP/1.1 200 OK", mem.trim(u8, header, &std.ascii.spaces));
         std.testing.allocator.free(header);
     }
 
@@ -1833,7 +1833,7 @@ test "HTTPS request on wikipedia main page" {
             content_length = try std.fmt.parseUnsigned(usize, hdr_contents[16..], 10);
         }
     }
-    std.testing.expect(content_length != null);
+    try std.testing.expect(content_length != null);
     const html_contents = try std.testing.allocator.alloc(u8, content_length.?);
     defer std.testing.allocator.free(html_contents);
 
@@ -1888,7 +1888,7 @@ test "HTTPS request on twitch oath2 endpoint" {
         .cert_verifier = .none,
         .protocols = &[_][]const u8{"http/1.1"},
     }, "id.twitch.tv");
-    std.testing.expectEqualStrings("http/1.1", client.protocol);
+    try std.testing.expectEqualStrings("http/1.1", client.protocol);
     defer client.close_notify() catch {};
 
     try client.writer().writeAll("GET /oauth2/validate HTTP/1.1\r\nHost: id.twitch.tv\r\nAccept: */*\r\n\r\n");
@@ -1906,7 +1906,7 @@ test "HTTPS request on twitch oath2 endpoint" {
             content_length = try std.fmt.parseUnsigned(usize, hdr_contents[16..], 10);
         }
     }
-    std.testing.expect(content_length != null);
+    try std.testing.expect(content_length != null);
     const html_contents = try std.testing.allocator.alloc(u8, content_length.?);
     defer std.testing.allocator.free(html_contents);
 
@@ -1928,7 +1928,7 @@ test "Connecting to expired.badssl.com returns an error" {
         break :blk &std.rand.DefaultCsprng.init(seed).random;
     };
 
-    std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
+    try std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
         .rand = rand,
         .reader = sock.reader(),
         .writer = sock.writer(),
@@ -1953,7 +1953,7 @@ test "Connecting to wrong.host.badssl.com returns an error" {
         break :blk &std.rand.DefaultCsprng.init(seed).random;
     };
 
-    std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
+    try std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
         .rand = rand,
         .reader = sock.reader(),
         .writer = sock.writer(),
@@ -1978,7 +1978,7 @@ test "Connecting to self-signed.badssl.com returns an error" {
         break :blk &std.rand.DefaultCsprng.init(seed).random;
     };
 
-    std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
+    try std.testing.expectError(error.CertificateVerificationFailed, client_connect(.{
         .rand = rand,
         .reader = sock.reader(),
         .writer = sock.writer(),
@@ -2024,5 +2024,5 @@ test "Connecting to client.badssl.com with a client certificate" {
 
     const line = try client.reader().readUntilDelimiterAlloc(std.testing.allocator, '\n', std.math.maxInt(usize));
     defer std.testing.allocator.free(line);
-    std.testing.expectEqualStrings("HTTP/1.1 200 OK\r", line);
+    try std.testing.expectEqualStrings("HTTP/1.1 200 OK\r", line);
 }

--- a/src/x509.zig
+++ b/src/x509.zig
@@ -885,12 +885,12 @@ fn expected_pem_certificate_chain(bytes: []const u8, certs: []const []const u8) 
     while (try it.next()) |cert_reader| : (idx += 1) {
         const result_bytes = try cert_reader.readAllAlloc(std.testing.allocator, std.math.maxInt(usize));
         defer std.testing.allocator.free(result_bytes);
-        std.testing.expectEqualSlices(u8, certs[idx], result_bytes);
+        try std.testing.expectEqualSlices(u8, certs[idx], result_bytes);
     }
     if (idx != certs.len) {
         std.debug.panic("Read {} certificates, wanted {}", .{ idx, certs.len });
     }
-    std.testing.expect((try it.next()) == null);
+    try std.testing.expect((try it.next()) == null);
 }
 
 fn expected_pem_certificate(bytes: []const u8, cert_bytes: []const u8) !void {
@@ -935,8 +935,8 @@ test "pemCertificateIterator" {
             const first_reader = (try it.next()) orelse return error.NoCertificate;
             var first_few: [8]u8 = undefined;
             const bytes = try first_reader.readAll(&first_few);
-            std.testing.expectEqual(first_few.len, bytes);
-            std.testing.expectEqualSlices(u8, github_der[0..bytes], &first_few);
+            try std.testing.expectEqual(first_few.len, bytes);
+            try std.testing.expectEqualSlices(u8, github_der[0..bytes], &first_few);
         }
 
         const next_reader = (try it.next()) orelse return error.NoCertificate;
@@ -950,8 +950,8 @@ test "pemCertificateIterator" {
                 std.debug.panic("index {}: expected 0x{X}, found 0x{X}", .{ idx, github_der[idx], byte });
             }
         }
-        std.testing.expectEqual(github_der.len, idx);
-        std.testing.expect((try it.next()) == null);
+        try std.testing.expectEqual(github_der.len, idx);
+        try std.testing.expect((try it.next()) == null);
     }
 }
 


### PR DESCRIPTION
Recent changes in zig master makes it possible for std.testing.exectXXX
to return errors. These changes takes this into account.