### PR TITLE
Update usage of endian builtin

### DIFF
--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,6 +1,6 @@
 pkgs:
   iguanaTLS:
-    version: 0.0.1
+    version: 0.0.2
     author: alexnask
     description: "Minimal, experimental TLS 1.2 implementation in Zig"
     license: MIT

--- a/src/asn1.zig
+++ b/src/asn1.zig
@@ -399,7 +399,7 @@ pub const der = struct {
                 enc.data[1 .. bytes_needed + 1],
                 mem.asBytes(&length)[0..bytes_needed],
             );
-            if (std.builtin.endian != .Big) {
+            if (std.builtin.target.cpu.arch.endian() != .Big) {
                 mem.reverse(u8, enc.data[1 .. bytes_needed + 1]);
             }
             enc.len = bytes_needed;
@@ -477,7 +477,7 @@ pub const der = struct {
         try der_reader.readNoEof(res_buf[0..length]);
         bytes_read.* += length;
 
-        if (std.builtin.endian != .Big) {
+        if (std.builtin.target.cpu.arch.endian() != .Big) {
             mem.reverse(u8, res_buf[0..length]);
         }
         return mem.bytesToValue(usize, &res_buf);


### PR DESCRIPTION
It looks like there has been a change in how the endian flag is exposed in the standard library.
Compiled with zig `0.8.0-dev.2591+4b69bd61e`

2 wikimedia tests in main.zig fail with OOM:

```
test "HTTPS request on wikipedia main page"... FAIL (CertificateVerificationFailed)
/opt/software/zig-0.8-dev/lib/std/heap/general_purpose_allocator.zig:606:13: 0x21d149 in std.heap.general_purpose_allocator.GeneralPurposeAllocator((struct std.heap.general_purpose_allocator.Config constant)).resize (test)
            return error.OutOfMemory;
            
test "HTTPS request on wikipedia alternate name"... FAIL (CertificateVerificationFailed)
/opt/software/zig-0.8-dev/lib/std/heap/general_purpose_allocator.zig:606:13: 0x21d149 in std.heap.general_purpose_allocator.GeneralPurposeAllocator((struct std.heap.general_purpose_allocator.Config constant)).resize (test)
            return error.OutOfMemory;
```

I was unable to verify the prior state as it doesn't seem the project builds with zig 0.7.1. The rest of the tests pass.
